### PR TITLE
feat: add input option to set Teraform init args

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ Use the following to control the action:
 | `comment-delete` | Delete previous comments made by the bot on the PR                 | false        |
 | `comment-title`  | The title to give the PR comment                                   | Plan changes |
 | `directory`      | Directory with the `*.tf` files to validate                        | .            |
-| `github-token`   | GitHub Token used to add comment to PR.  Required to add comments. |              |
+| `github-token`   | GitHub Token used to add comment to PR (required to add comments). |              |
+| `terraform-init` | Custom Terraform init args                                         |              |
 | `terragrunt`     | Use Terragrunt instead of Terraform                                | false        |
 
 # Examples
@@ -53,6 +54,13 @@ Use the following to control the action:
   uses: cds-snc/terraform-plan
   with:
     add-comment: false
+
+# Run Terraform plan custom Terraform init args
+- name: Terraform plan
+  uses: cds-snc/terraform-plan
+  with:
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+    terraform-init: -backend-config="region=ca-central-1"
 ```
 
 # Contributing

--- a/action.yaml
+++ b/action.yaml
@@ -27,6 +27,10 @@ inputs:
     description: 'GitHub Token used to add comment to PR'
     required: false
     default: 'false'
+  terraform-init:
+    description: 'Custom Terraform init args'
+    required: false
+    default: ''     
   terragrunt:
     description: 'Use Terragrunt instead of Terraform'
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -14837,17 +14837,21 @@ const action = async () => {
   const isCommentDelete = core.getInput("comment-delete") === "true";
   const isTerragrunt = core.getInput("terragrunt") === "true";
 
+  const binary = isTerragrunt ? "terragrunt" : "terraform";
   const commentTitle = core.getInput("comment-title");
   const directory = core.getInput("directory");
-  const binary = isTerragrunt ? "terragrunt" : "terraform";
+  const terraformInit = core.getInput("terraform-init");
   const token = core.getInput("github-token");
   const octokit = token !== "false" ? github.getOctokit(token) : undefined;
 
   const commands = [
-    { key: "init", exec: `${binary} init` },
+    { key: "init", exec: `${binary} init ${terraformInit}` },
     { key: "validate", exec: `${binary} validate` },
     { key: "fmt", exec: `${binary} fmt --check` },
-    { key: "plan", exec: `${binary} plan -no-color -out=plan.tfplan` },
+    {
+      key: "plan",
+      exec: `${binary} plan -no-color -input=false -out=plan.tfplan`,
+    },
     { key: "show", exec: `${binary} show -json plan.tfplan`, depends: "plan" },
   ];
   let results = {};

--- a/src/action.js
+++ b/src/action.js
@@ -15,17 +15,21 @@ const action = async () => {
   const isCommentDelete = core.getInput("comment-delete") === "true";
   const isTerragrunt = core.getInput("terragrunt") === "true";
 
+  const binary = isTerragrunt ? "terragrunt" : "terraform";
   const commentTitle = core.getInput("comment-title");
   const directory = core.getInput("directory");
-  const binary = isTerragrunt ? "terragrunt" : "terraform";
+  const terraformInit = core.getInput("terraform-init");
   const token = core.getInput("github-token");
   const octokit = token !== "false" ? github.getOctokit(token) : undefined;
 
   const commands = [
-    { key: "init", exec: `${binary} init` },
+    { key: "init", exec: `${binary} init ${terraformInit}` },
     { key: "validate", exec: `${binary} validate` },
     { key: "fmt", exec: `${binary} fmt --check` },
-    { key: "plan", exec: `${binary} plan -no-color -out=plan.tfplan` },
+    {
+      key: "plan",
+      exec: `${binary} plan -no-color -input=false -out=plan.tfplan`,
+    },
     { key: "show", exec: `${binary} show -json plan.tfplan`, depends: "plan" },
   ];
   let results = {};

--- a/src/action.test.js
+++ b/src/action.test.js
@@ -22,15 +22,18 @@ describe("action", () => {
   test("default flow", async () => {
     execCommand.mockReturnValue({ isSuccess: true, output: "{}" });
     when(core.getInput).calledWith("directory").mockReturnValue("foo");
+    when(core.getInput)
+      .calledWith("terraform-init")
+      .mockReturnValue("-backend-config='bucket=some-bucket'");
 
     await action();
 
     expect(execCommand.mock.calls.length).toBe(5);
     expect(execCommand.mock.calls).toEqual([
-      ["terraform init", "foo"],
+      ["terraform init -backend-config='bucket=some-bucket'", "foo"],
       ["terraform validate", "foo"],
       ["terraform fmt --check", "foo"],
-      ["terraform plan -no-color -out=plan.tfplan", "foo"],
+      ["terraform plan -no-color -input=false -out=plan.tfplan", "foo"],
       ["terraform show -json plan.tfplan", "foo"],
     ]);
     expect(addComment.mock.calls.length).toBe(0);
@@ -40,16 +43,17 @@ describe("action", () => {
   test("terragrunt flow", async () => {
     execCommand.mockReturnValue({ isSuccess: true, output: "{}" });
     when(core.getInput).calledWith("directory").mockReturnValue("bar");
+    when(core.getInput).calledWith("terraform-init").mockReturnValue("");
     when(core.getInput).calledWith("terragrunt").mockReturnValue("true");
 
     await action();
 
     expect(execCommand.mock.calls.length).toBe(5);
     expect(execCommand.mock.calls).toEqual([
-      ["terragrunt init", "bar"],
+      ["terragrunt init ", "bar"],
       ["terragrunt validate", "bar"],
       ["terragrunt fmt --check", "bar"],
-      ["terragrunt plan -no-color -out=plan.tfplan", "bar"],
+      ["terragrunt plan -no-color -input=false -out=plan.tfplan", "bar"],
       ["terragrunt show -json plan.tfplan", "bar"],
     ]);
     expect(getPlanChanges.mock.calls.length).toBe(1);


### PR DESCRIPTION
# Summary 
* Add action input to set custom Terraform init args.
* Add `-input=false` to Terraform plan command to prevent stuck plan due to missing variables.
