### PR TITLE
feat: add toggles for plan and conftest limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Use the following to control the action:
 | `github-token`   | GitHub Token used to add comment to PR (required to add comments). |              |
 | `terraform-init` | Custom Terraform init args                                         |              |
 | `terragrunt`     | Use Terragrunt instead of Terraform                                | false        |
+| `plan-character-limit` | Character limit for Terraform plan output                    | 30000        |
+| `conftest-character-limit` | Character limit for Conftest output                      | 2000         |
 
 # Examples
 ```yaml

--- a/src/github.js
+++ b/src/github.js
@@ -26,7 +26,7 @@ Plan: {{ changes.resources.create }} to add, {{ changes.resources.update }} to c
 <summary>Show plan</summary>
 
 \`\`\`terraform
-{{ plan|safe|truncate(63000) }}
+{{ plan|safe|truncate(planLimit) }}
 \`\`\`
 
 </details>
@@ -35,7 +35,7 @@ Plan: {{ changes.resources.create }} to add, {{ changes.resources.update }} to c
 <summary>Show Conftest results</summary>
 
 \`\`\`sh
-{{ results.conftest.output|safe|truncate(1000) }}
+{{ results.conftest.output|safe|truncate(conftestLimit) }}
 \`\`\`
 
 </details>
@@ -50,7 +50,15 @@ Plan: {{ changes.resources.create }} to add, {{ changes.resources.update }} to c
  * @param {Object} results Results for all the Terraform commands
  * @param {Object} changes Resource and output changes for the plan
  */
-const addComment = async (octokit, context, title, results, changes) => {
+const addComment = async (
+  octokit,
+  context,
+  title,
+  results,
+  changes,
+  planLimit,
+  conftestLimit
+) => {
   const format = cleanFormatOutput(results.fmt.output);
   const plan = removePlanRefresh(results.plan.output);
   const comment = nunjucks.renderString(commentTemplate, {
@@ -59,6 +67,8 @@ const addComment = async (octokit, context, title, results, changes) => {
     format: format,
     results: results,
     title: title,
+    planLimit: planLimit,
+    conftestLimit: conftestLimit,
   });
   await octokit.rest.issues.createComment({
     ...context.repo,

--- a/test/action.test.js
+++ b/test/action.test.js
@@ -218,7 +218,7 @@ describe("action", () => {
       },
       { isChanges: true },
       30000,
-      2000
+      2000,
     ]);
   });
 

--- a/test/action.test.js
+++ b/test/action.test.js
@@ -217,6 +217,8 @@ describe("action", () => {
         conftest: { isSuccess: true, output: "{}" },
       },
       { isChanges: true },
+      30000,
+      2000
     ]);
   });
 


### PR DESCRIPTION
# Summary | Résumé

- Adds plan-character-limit which sets the number of characters to
  truncate the plan output to
- Adds conftest-character-limit which sets the number of characters to
  truncate the conftest output to

