### PR TITLE
feat: generate Software Bill of Materials

### DIFF
--- a/.github/workflows/generate-sbom.yml
+++ b/.github/workflows/generate-sbom.yml
@@ -1,0 +1,29 @@
+name: Generate SBOM
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - package-lock.json
+      - .github/workflows/generate-sbom.yml
+  push:
+    branches:
+      - main
+    paths:
+      - package-lock.json
+      - .github/workflows/generate-sbom.yml
+
+jobs:
+  generate-sbom:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Generate app SBOM
+        uses: cds-snc/security-tools/.github/actions/generate-sbom@4c6b386722985552f3f008d04279a3f01402cc35 # tag=v1
+        with:
+          dependency_track_api_key: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}
+          project_name: terraform-plan/app
+          project_type: node        

--- a/test/conftest-deny/conftest-deny.tf
+++ b/test/conftest-deny/conftest-deny.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.37"
+      version = "~> 4.15"
     }
 
   }


### PR DESCRIPTION
# Summary 
Add GitHub workflows to generate SBOMs and upload them
to Dependency-Track. This will allow us to have a view of all
the dependencies used by the org and their potential
vulnerabilities.

# Related
* cds-snc/platform-sre-security-support#94