### PR TITLE
chore: remove `npm audit` from CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,5 +24,4 @@ jobs:
       - run: npm ci
       - run: npm run lint
       - run: npm run format:check
-      - run: npm audit
       - run: npm test


### PR DESCRIPTION
# Summary 
Dependency updates are handled via Renovate and Dependabot and no longer need to be manually caught in the CI workflow.