### PR TITLE
fix: install dependencies before Renovate build

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,7 @@
   ],
   "postUpgradeTasks": {
     "commands": [
+      "npm install",
       "npm run build"
     ],
     "fileFilters": [


### PR DESCRIPTION
# Summary
Update the Renovate postUpdateTasks to perform an
`npm install` before the build.  This will make sure the devDependencies exist.