### PR TITLE
chore: upgrade action to Node.js 20

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -60,7 +60,7 @@ inputs:
     required: false
     default: 'false'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 
 branding:


### PR DESCRIPTION
# Summary
Upgrade to Node.js 20 as 16 is deprecated for actions.