### PR TITLE
fix: limit number of parallel PR test runs

### DIFF
--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -19,6 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      max-parallel: 10
       matrix:
         include:
           # Standard tests (terraform)


### PR DESCRIPTION
# Summary
Limit to 10 matrix jobs at a time to prevent GitHub rate limiting which is causing intermittent failures of the CI.