### PR TITLE
feat: add drift detection workflow example and update README with drift output options and security controls met

### DIFF
--- a/examples/drift-detection.yml
+++ b/examples/drift-detection.yml
@@ -1,0 +1,45 @@
+name: Drift detection
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Adjust as needed (this runs daily at 03:15 UTC)
+    - cron: "15 3 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  drift:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Install Terraform/OpenTofu and other tooling required by the action.
+      - name: Setup terraform tools
+        uses: cds-snc/terraform-tools-setup@v1
+
+      - name: Terraform plan (drift check)
+        id: plan
+        uses: cds-snc/terraform-plan@v1
+        with:
+          # Avoid PR comments in scheduled runs.
+          comment: false
+          comment-delete: false
+
+          # Optionally set this if your Terraform lives in a subfolder.
+          # directory: ./infra
+
+      - name: Fail if drift detected
+        if: ${{ fromJson(steps.plan.outputs.drift-output).hasChanges }}
+        run: |
+          echo "Drift detected (Terraform/OpenTofu plan contains changes)."
+          exit 1
+
+      - name: Fail if plan failed
+        if: ${{ fromJson(steps.plan.outputs.drift-output).status == 'failed' }}
+        run: |
+          echo "Drift check failed (action status=failed)."
+          exit 1

--- a/package-lock.json
+++ b/package-lock.json
@@ -107,7 +107,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1345,7 +1344,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -1966,7 +1964,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2249,7 +2246,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2656,7 +2652,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3490,7 +3485,6 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",


### PR DESCRIPTION
This pull request introduces support for drift detection in Terraform/OpenTofu workflows, including documentation, configuration options, and an example workflow. The most important changes are:

**Drift Detection Feature:**

* Added Documentation for `enable-drift-output` option (enabled by default) to emit a `drift-output` action output containing a JSON summary of drift status and resource changes. (`README.md`)
* Documented how to use the action for drift detection, including a description of the `drift-output` format and guidance on alerting and evidence creation. (`README.md`)
* Added an example workflow (`examples/drift-detection.yml`) showing how to schedule drift detection, check for drift using the new output, and fail the workflow if drift is detected or the plan fails.
* Added a new `open-tofu` option to allow using OpenTofu instead of Terraform. (`README.md`)

**Compliance Documentation:**

* Added sections mapping drift detection to ITSG-33 and NIST SP 800-53 configuration management controls, explaining how this feature supports compliance requirements. (`README.md`)

